### PR TITLE
Make Period and Offset configurable at Construction

### DIFF
--- a/include/reactor-uc/macros.h
+++ b/include/reactor-uc/macros.h
@@ -122,14 +122,15 @@ typedef struct Input Input;
 
 typedef struct Timer Timer;
 
-#define DEFINE_TIMER(TimerName, EffectSize, Offset, Period)                                                            \
+#define DEFINE_TIMER_STRUCT(TimerName, EffectSize)                                                                     \
   typedef struct {                                                                                                     \
     Timer super;                                                                                                       \
     Reaction *effects[(EffectSize)];                                                                                   \
-  } TimerName;                                                                                                         \
-                                                                                                                       \
-  void TimerName##_ctor(TimerName *self, Reactor *parent) {                                                            \
-    Timer_ctor(&self->super, parent, Offset, Period, self->effects, EffectSize);                                       \
+  } TimerName;
+
+#define DEFINE_TIMER_CTOR(TimerName)                                                                                   \
+  void TimerName##_ctor(TimerName *self, Reactor *parent, interval_t offset, interval_t period) {                      \
+    Timer_ctor(&self->super, parent, offset, period, self->effects, sizeof(self->effects) / sizeof(self->effects[0])); \
   }
 
 typedef struct Reaction Reaction;

--- a/test/unit/delayed_conn_test.c
+++ b/test/unit/delayed_conn_test.c
@@ -2,7 +2,8 @@
 #include "unity.h"
 
 // Components of Reactor Sender
-DEFINE_TIMER(Timer1, 1, 0, MSEC(100))
+DEFINE_TIMER_STRUCT(Timer1, 1)
+DEFINE_TIMER_CTOR(Timer1)
 DEFINE_REACTION(Sender, 0, 0);
 DEFINE_OUTPUT_PORT(Out, 1)
 
@@ -27,7 +28,7 @@ void Sender_ctor(Sender *self, Reactor *parent, Environment *env) {
   self->_triggers[0] = (Trigger *)&self->timer;
   Reactor_ctor(&self->super, "Sender", env, parent, NULL, 0, self->_reactions, 1, self->_triggers, 1);
   Sender_0_ctor(&self->reaction, &self->super);
-  Timer1_ctor(&self->timer, &self->super);
+  Timer1_ctor(&self->timer, &self->super, 0, MSEC(100));
   Out_ctor(&self->out, &self->super);
 
   TIMER_REGISTER_EFFECT(self->timer, self->reaction);

--- a/test/unit/port_test.c
+++ b/test/unit/port_test.c
@@ -2,7 +2,8 @@
 #include "unity.h"
 
 // Components of Reactor Sender
-DEFINE_TIMER(Timer1, 1, 0, SEC(1))
+DEFINE_TIMER_STRUCT(Timer1, 1)
+DEFINE_TIMER_CTOR(Timer1)
 DEFINE_REACTION(Sender, 0, 0)
 DEFINE_OUTPUT_PORT(Out, 1)
 
@@ -27,7 +28,7 @@ void Sender_ctor(Sender *self, Reactor *parent, Environment *env) {
   self->_triggers[0] = (Trigger *)&self->timer;
   Reactor_ctor(&self->super, "Sender", env, parent, NULL, 0, self->_reactions, 1, self->_triggers, 1);
   Sender_0_ctor(&self->reaction, &self->super);
-  Timer1_ctor(&self->timer, &self->super);
+  Timer1_ctor(&self->timer, &self->super, 0, SEC(1));
   Out_ctor(&self->out, &self->super);
   TIMER_REGISTER_EFFECT(self->timer, self->reaction);
   OUTPUT_REGISTER_SOURCE(self->out, self->reaction);

--- a/test/unit/timer_test.c
+++ b/test/unit/timer_test.c
@@ -1,7 +1,8 @@
 #include "reactor-uc/reactor-uc.h"
 #include "unity.h"
 
-DEFINE_TIMER(MyTimer, 1, 0, MSEC(100))
+DEFINE_TIMER_STRUCT(MyTimer, 1)
+DEFINE_TIMER_CTOR(MyTimer)
 DEFINE_REACTION(MyReactor, 0, 0)
 
 typedef struct {
@@ -21,7 +22,7 @@ void MyReactor_ctor(MyReactor *self, Environment *env) {
   self->_triggers[0] = (Trigger *)&self->timer;
   Reactor_ctor(&self->super, "MyReactor", env, NULL, NULL, 0, self->_reactions, 1, self->_triggers, 1);
   MyReactor_0_ctor(&self->my_reaction, &self->super);
-  MyTimer_ctor(&self->timer, &self->super);
+  MyTimer_ctor(&self->timer, &self->super, 0, MSEC(100));
   TIMER_REGISTER_EFFECT(self->timer, self->my_reaction);
 }
 


### PR DESCRIPTION
- also split `DEFINE_TIMER` macro into `DEFINE_TIMER_STRUCT` and `DEFINE_TIMER_CTOR`

closes #77 