### PR TITLE
Migrate (federated | delayed) connection.is_physical to ENUM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
         run: |
           source env.bash
           make format-check
-          make test
+          make unit-test
+          make examples
           make coverage
       - name: Coverage
         uses: romeovs/lcov-reporter-action@2a28ec3e25fb7eae9cb537e9141603486f810d1a

--- a/include/reactor-uc/connection.h
+++ b/include/reactor-uc/connection.h
@@ -15,6 +15,8 @@ typedef struct DelayedConnection DelayedConnection;
 typedef struct Port Port;
 typedef struct Output Output;
 
+typedef enum { LOGICAL_CONNECTION, PHYSICAL_CONNECTION } ConnectionType;
+
 struct Connection {
   Trigger super;
   Port *upstream;                // Single upstream port
@@ -39,13 +41,13 @@ void LogicalConnection_ctor(LogicalConnection *self, Reactor *parent, Port **dow
 struct DelayedConnection {
   Connection super;
   interval_t delay;
-  bool is_physical;
+  ConnectionType type;
   EventPayloadPool payload_pool;
   void *staged_payload_ptr;
 };
 
 void DelayedConnection_ctor(DelayedConnection *self, Reactor *parent, Port **downstreams, size_t num_downstreams,
-                            interval_t delay, bool is_physical, size_t payload_size, void *payload_buf,
+                            interval_t delay, ConnectionType type, size_t payload_size, void *payload_buf,
                             bool *payload_used_buf, size_t payload_buf_capacity);
 
 #endif

--- a/include/reactor-uc/federated.h
+++ b/include/reactor-uc/federated.h
@@ -45,8 +45,8 @@ void FederatedOutputConnection_ctor(FederatedOutputConnection *self, Reactor *pa
 // A single input connection to this federate. Has a single upstream port
 struct FederatedInputConnection {
   Connection super;
-  interval_t delay;     // The delay of this connection
-  bool is_physical;     // Is the connection physical?
+  interval_t delay; // The delay of this connection
+  ConnectionType type;
   tag_t last_known_tag; // The latest tag this input is known at.
   instant_t safe_to_assume_absent;
   EventPayloadPool payload_pool;
@@ -54,7 +54,7 @@ struct FederatedInputConnection {
   void (*schedule)(FederatedInputConnection *self, TaggedMessage *msg);
 };
 
-void FederatedInputConnection_ctor(FederatedInputConnection *self, Reactor *parent, interval_t delay, bool is_physical,
-                                   Port **downstreams, size_t downstreams_size, void *payload_buf,
+void FederatedInputConnection_ctor(FederatedInputConnection *self, Reactor *parent, interval_t delay,
+                                   ConnectionType type, Port **downstreams, size_t downstreams_size, void *payload_buf,
                                    bool *payload_used_buf, size_t payload_size, size_t payload_buf_capacity);
 #endif

--- a/src/connection.c
+++ b/src/connection.c
@@ -117,7 +117,7 @@ void DelayedConnection_cleanup(Trigger *trigger) {
     Scheduler *sched = &env->scheduler;
 
     tag_t base_tag = ZERO_TAG;
-    if (self->is_physical) {
+    if (self->type == PHYSICAL_CONNECTION) {
       base_tag.time = env->get_physical_time(env);
     } else {
       base_tag = sched->current_tag;
@@ -146,12 +146,12 @@ void DelayedConnection_trigger_downstreams(Connection *_self, const void *value,
 }
 
 void DelayedConnection_ctor(DelayedConnection *self, Reactor *parent, Port **downstreams, size_t num_downstreams,
-                            interval_t delay, bool is_physical, size_t payload_size, void *payload_buf,
+                            interval_t delay, ConnectionType type, size_t payload_size, void *payload_buf,
                             bool *payload_used_buf, size_t payload_buf_capacity) {
 
   self->delay = delay;
   self->staged_payload_ptr = NULL;
-  self->is_physical = is_physical;
+  self->type = type;
   EventPayloadPool_ctor(&self->payload_pool, payload_buf, payload_used_buf, payload_size, payload_buf_capacity);
   Connection_ctor(&self->super, TRIG_CONN_DELAYED, parent, downstreams, num_downstreams, &self->payload_pool,
                   DelayedConnection_prepare, DelayedConnection_cleanup, DelayedConnection_trigger_downstreams);

--- a/src/federated.c
+++ b/src/federated.c
@@ -98,14 +98,14 @@ void FederatedInputConnection_cleanup(Trigger *trigger) {
   trigger->is_present = false;
 }
 
-void FederatedInputConnection_ctor(FederatedInputConnection *self, Reactor *parent, interval_t delay, bool is_physical,
-                                   Port **downstreams, size_t downstreams_size, void *payload_buf,
+void FederatedInputConnection_ctor(FederatedInputConnection *self, Reactor *parent, interval_t delay,
+                                   ConnectionType type, Port **downstreams, size_t downstreams_size, void *payload_buf,
                                    bool *payload_used_buf, size_t payload_size, size_t payload_buf_capacity) {
   EventPayloadPool_ctor(&self->payload_pool, payload_buf, payload_used_buf, payload_size, payload_buf_capacity);
   Connection_ctor(&self->super, TRIG_CONN_FEDERATED_INPUT, parent, downstreams, downstreams_size, &self->payload_pool,
                   FederatedInputConnection_prepare, FederatedInputConnection_cleanup, NULL);
   self->delay = delay;
-  self->is_physical = is_physical;
+  self->type = type;
   self->last_known_tag = NEVER_TAG;
   self->safe_to_assume_absent = FOREVER;
 }
@@ -124,7 +124,7 @@ void FederatedConnectionBundle_msg_received_cb(FederatedConnectionBundle *self, 
   env->platform->enter_critical_section(env->platform);
 
   tag_t base_tag = ZERO_TAG;
-  if (input->is_physical) {
+  if (input->type == PHYSICAL_CONNECTION) {
     base_tag.time = env->get_physical_time(env);
   } else {
     base_tag.time = msg->tag.time;


### PR DESCRIPTION
Similar to my feedback on the Action.is_physical I also updated the DelayedConnection and FederatedConnection to use an ENUM instead of the is_physical boolean.

I am not sure if maybe the Kotlin Compiler needs to be adapted to this and I am not confident in that area yet, so I left it out for now