### PR TITLE
Remove `dest_channel_id` from NetworkChannel

### DIFF
--- a/include/reactor-uc/network_channel.h
+++ b/include/reactor-uc/network_channel.h
@@ -23,11 +23,6 @@ typedef struct NetworkChannel NetworkChannel;
 
 struct NetworkChannel {
   /**
-   * @brief Used to identify this NetworkChannel among other NetworkChannels at the other federate.
-   */
-  size_t dest_channel_id;
-
-  /**
    * @brief Expected time until a connection is established after calling @p try_connect.
    */
   interval_t expected_try_connect_duration;

--- a/src/platform/posix/tcp_ip_channel.c
+++ b/src/platform/posix/tcp_ip_channel.c
@@ -469,7 +469,7 @@ static void TcpIpChannel_free(NetworkChannel *untyped_self) {
   self->super.close_connection((NetworkChannel *)self);
 }
 
-NetworkChannelState TcpIpChannel_get_state(NetworkChannel *untyped_self) {
+static NetworkChannelState TcpIpChannel_get_connection_state(NetworkChannel *untyped_self) {
   TcpIpChannel *self = (TcpIpChannel *)untyped_self;
   return self->state;
 }
@@ -486,12 +486,12 @@ void TcpIpChannel_ctor(TcpIpChannel *self, const char *host, unsigned short port
   self->fd = 0;
   self->state = NETWORK_CHANNEL_STATE_UNINITIALIZED;
 
+  self->super.get_connection_state = TcpIpChannel_get_connection_state;
   self->super.open_connection = TcpIpChannel_open_connection;
   self->super.try_connect = TcpIpChannel_try_connect;
   self->super.close_connection = TcpIpChannel_close_connection;
   self->super.send_blocking = TcpIpChannel_send_blocking;
   self->super.register_receive_callback = TcpIpChannel_register_receive_callback;
-  self->super.get_connection_state = TcpIpChannel_get_state;
   self->super.free = TcpIpChannel_free;
   self->receive_callback = NULL;
   self->federated_connection = NULL;


### PR DESCRIPTION
I think it is more reasonable to not duplicate this value if we anyways for example have the ports or file descriptors stored in the concrete channel implementation structs.