### PR TITLE
Only call prepare once on port->set

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -22,10 +22,11 @@ void Port_prepare(Trigger *_self, Event *event) {
 }
 
 void Port_set(Port *self, const void *value) {
-
   if (self->effects.size > 0 || self->observers.size > 0) {
     memcpy(self->value_ptr, value, self->value_size);
-    Port_prepare(&self->super, NULL);
+    if (!self->super.is_present) {
+      Port_prepare(&self->super, NULL);
+    }
   }
 
   for (size_t i = 0; i < self->conns_out_registered; i++) {


### PR DESCRIPTION
Fixes a bug where if lf_set is called multiple times on an output port that triggers reactions in its parent then we try to add those reactions multiple times to the reaction queue.