### PR TITLE
Delete LF_SRC_GEN_PATH if make clean is run on RIOT OS with riot-lfc.mk

### DIFF
--- a/make/riot/riot-lfc.mk
+++ b/make/riot/riot-lfc.mk
@@ -11,16 +11,28 @@ APPLICATION ?= $(LF_MAIN)
 # Path of generated lf c-code
 LF_SRC_GEN_PATH ?= $(CURDIR)/src-gen/$(LF_MAIN)
 
-# Include the Makefile of the generated target application
-include $(LF_SRC_GEN_PATH)/Makefile
+# Only include generated files if build target is not "clean"
+# In this case the src-gen folder was deleted
+ifeq ($(MAKECMDGOALS),clean)
+  # Delete src-gen folder if build target is "clean"
+  _ :=  $(shell rm -rf $(LF_SRC_GEN_PATH))
+else
+  # Include the Makefile of the generated target application
+  include $(LF_SRC_GEN_PATH)/Makefile
 
-# Include generated c files
-SRC += $(patsubst %, $(LF_SRC_GEN_PATH)/%, $(LFC_GEN_SOURCES))
+  # Include generated c files
+  SRC += $(patsubst %, $(LF_SRC_GEN_PATH)/%, $(LFC_GEN_SOURCES))
 
-# Include generated main file
-SRC += $(LF_SRC_GEN_PATH)/${LFC_GEN_MAIN}
+  # Include generated main file
+  SRC += $(LF_SRC_GEN_PATH)/${LFC_GEN_MAIN}
 
-# Include generated h files
-CFLAGS += -I$(LF_SRC_GEN_PATH)
+  # Include generated h files
+  CFLAGS += -I$(LF_SRC_GEN_PATH)
+endif
+
+
+ifneq ($(MAKECMDGOALS),clean)
+
+endif
 
 include $(RIOT_MK_DIR)/riot.mk


### PR DESCRIPTION
This fixes: lf-lang/lf-riot-uc-template/issues/6