### PR TITLE
Validate that the port sizes are less than the MTU

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   ci:
     name: Run benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/flexpret.yml
+++ b/.github/workflows/flexpret.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ci:
     name: Build FlexPRET examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/memory.yml
+++ b/.github/workflows/memory.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   ci:
     name: Report memory usage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # To get the potential changes to CI
       - name: Checkout

--- a/.github/workflows/pico.yml
+++ b/.github/workflows/pico.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ci:
     name: Build examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ci:
     name: Build examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/riot.yml
+++ b/.github/workflows/riot.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ci:
     name: Build examples and run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container:
       image: riot/riotbuild:latest
     env:

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   ci:
     name: Build examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       REACTOR_UC_PATH: ${{ github.workspace }}
     steps:

--- a/include/reactor-uc/federated.h
+++ b/include/reactor-uc/federated.h
@@ -11,7 +11,7 @@ typedef struct FederatedInputConnection FederatedInputConnection;
 typedef struct NetworkChannel NetworkChannel;
 
 // returns how many bytes of the buffer were used by the serialized string
-typedef size_t (*serialize_hook)(const void *user_struct, size_t user_struct_size, unsigned char *msg_buffer);
+typedef ssize_t (*serialize_hook)(const void *user_struct, size_t user_struct_size, unsigned char *msg_buffer);
 
 // returns if the deserialization was successful
 typedef lf_ret_t (*deserialize_hook)(void *user_struct, const unsigned char *msg_buffer, size_t msg_size);

--- a/include/reactor-uc/serialization.h
+++ b/include/reactor-uc/serialization.h
@@ -5,6 +5,8 @@
 #include "reactor-uc/error.h"
 #include <stddef.h>
 
+// The maximum size of a serialized payload. 
+// NOTE: This MUST match the max size of the payload in the protobuf message definition.
 #ifndef SERIALIZATION_MAX_PAYLOAD_SIZE
 #define SERIALIZATION_MAX_PAYLOAD_SIZE 832
 #endif

--- a/include/reactor-uc/serialization.h
+++ b/include/reactor-uc/serialization.h
@@ -3,11 +3,16 @@
 
 #include "proto/message.pb.h"
 #include "reactor-uc/error.h"
+#include <stddef.h>
+
+#ifndef SERIALIZATION_MAX_PAYLOAD_SIZE
+#define SERIALIZATION_MAX_PAYLOAD_SIZE 832
+#endif
 
 int serialize_to_protobuf(const FederateMessage *message, unsigned char *buffer, size_t buffer_size);
 int deserialize_from_protobuf(FederateMessage *message, const unsigned char *buffer, size_t buffer_size);
 
 lf_ret_t deserialize_payload_default(void *user_struct, const unsigned char *msg_buf, size_t msg_size);
 
-size_t serialize_payload_default(const void *user_struct, size_t user_struct_size, unsigned char *msg_buf);
+ssize_t serialize_payload_default(const void *user_struct, size_t user_struct_size, unsigned char *msg_buf);
 #endif // REACTOR_UC_SERIALIZATION_H

--- a/include/reactor-uc/serialization.h
+++ b/include/reactor-uc/serialization.h
@@ -5,7 +5,7 @@
 #include "reactor-uc/error.h"
 #include <stddef.h>
 
-// The maximum size of a serialized payload. 
+// The maximum size of a serialized payload.
 // NOTE: This MUST match the max size of the payload in the protobuf message definition.
 #ifndef SERIALIZATION_MAX_PAYLOAD_SIZE
 #define SERIALIZATION_MAX_PAYLOAD_SIZE 832

--- a/src/serialization.c
+++ b/src/serialization.c
@@ -31,11 +31,17 @@ int deserialize_from_protobuf(FederateMessage *message, const unsigned char *buf
 }
 
 lf_ret_t deserialize_payload_default(void *user_struct, const unsigned char *msg_buf, size_t msg_size) {
-  memcpy(user_struct, msg_buf, MIN(msg_size, 832)); // TODO: 832 is a magic number
+  if (msg_size > SERIALIZATION_MAX_PAYLOAD_SIZE) {
+    return LF_ERR;
+  }
+  memcpy(user_struct, msg_buf, msg_size);
   return LF_OK;
 }
 
-size_t serialize_payload_default(const void *user_struct, size_t user_struct_size, unsigned char *msg_buf) {
-  memcpy(msg_buf, user_struct, MIN(user_struct_size, 832)); // TODO: 832 is a magic number
-  return MIN(user_struct_size, 832);                        // TODO: 832 is a magic number
+ssize_t serialize_payload_default(const void *user_struct, size_t user_struct_size, unsigned char *msg_buf) {
+  if (user_struct_size > SERIALIZATION_MAX_PAYLOAD_SIZE) {
+    return -1;
+  }
+  memcpy(msg_buf, user_struct, user_struct_size);
+  return user_struct_size;
 }


### PR DESCRIPTION
This PR addresses the issue that we have a max size for messages sent through a NetworkChannel. The default value is 800-something. This PR validates that all federate ports have data types less than this. Also it treats it as a runtime error if we try to serialize a message that is too big