### PR TITLE
Remove platform from generated NETWORK_CHANNEL_X CFLAG

### DIFF
--- a/examples/riot/coap_federated_lf/CoapFederatedLF/r1/run_lfc.sh
+++ b/examples/riot/coap_federated_lf/CoapFederatedLF/r1/run_lfc.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 LF_MAIN=CoapFederatedLF
 
 $REACTOR_UC_PATH/lfc/bin/lfc-dev ../../src/$LF_MAIN.lf -n -o .

--- a/examples/riot/coap_federated_lf/CoapFederatedLF/r2/run_lfc.sh
+++ b/examples/riot/coap_federated_lf/CoapFederatedLF/r2/run_lfc.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 LF_MAIN=CoapFederatedLF
 
 $REACTOR_UC_PATH/lfc/bin/lfc-dev ../../src/$LF_MAIN.lf -n -o .

--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMakeGenerator.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMakeGenerator.kt
@@ -61,8 +61,8 @@ class UcMakeGeneratorFederated(
         channelTypes.joinWithLn {
           when (it) {
             NetworkChannelType.TCP_IP -> "CFLAGS += -DNETWORK_CHANNEL_TCP"
-            NetworkChannelType.COAP_UDP_IP ->
-                "CFLAGS += -DNETWORK_CHANNEL_COAP"
+            NetworkChannelType.COAP_UDP_IP -> "CFLAGS += -DNETWORK_CHANNEL_COAP"
+            NetworkChannelType.UART -> "CFLAGS += -DNETWORK_CHANNEL_UART"
             NetworkChannelType.NONE -> ""
             NetworkChannelType.CUSTOM -> ""
           }

--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMakeGenerator.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMakeGenerator.kt
@@ -60,9 +60,9 @@ class UcMakeGeneratorFederated(
     val channelTypesCompileDefs =
         channelTypes.joinWithLn {
           when (it) {
-            NetworkChannelType.TCP_IP -> "CFLAGS += -DNETWORK_CHANNEL_TCP_RIOT"
+            NetworkChannelType.TCP_IP -> "CFLAGS += -DNETWORK_CHANNEL_TCP"
             NetworkChannelType.COAP_UDP_IP ->
-                "CFLAGS += -DNETWORK_CHANNEL_COAP_RIOT" // TODO: Abstract RIOT away!
+                "CFLAGS += -DNETWORK_CHANNEL_COAP"
             NetworkChannelType.NONE -> ""
             NetworkChannelType.CUSTOM -> ""
           }

--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMakeGenerator.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcMakeGenerator.kt
@@ -62,7 +62,6 @@ class UcMakeGeneratorFederated(
           when (it) {
             NetworkChannelType.TCP_IP -> "CFLAGS += -DNETWORK_CHANNEL_TCP"
             NetworkChannelType.COAP_UDP_IP -> "CFLAGS += -DNETWORK_CHANNEL_COAP"
-            NetworkChannelType.UART -> "CFLAGS += -DNETWORK_CHANNEL_UART"
             NetworkChannelType.NONE -> ""
             NetworkChannelType.CUSTOM -> ""
           }


### PR DESCRIPTION
We renamed `NETWORK_CHANNEL_COAP_RIOT` etc. to `NETWORK_CHANNEL_COAP` etc. 
This updates the compiler to also comply with this change and makes the makefile RIOT independent again 🥳