### PR TITLE
Disable clock-sync on RIOT platform tests

### DIFF
--- a/examples/posix/federated/receiver.c
+++ b/examples/posix/federated/receiver.c
@@ -94,7 +94,7 @@ LF_REACTOR_CTOR_SIGNATURE(MainRecv) {
   lf_connect_federated_input(&self->Receiver_Sender_bundle.inputs[0]->super, &self->receiver->in[0].super);
 }
 
-LF_ENTRY_POINT_FEDERATED(MainRecv,32,32,32, SEC(1), true, 1)
+LF_ENTRY_POINT_FEDERATED(MainRecv,32,32,32, SEC(1), true, 1, true)
 
 int main() {
   lf_start();

--- a/examples/posix/federated/sender.c
+++ b/examples/posix/federated/sender.c
@@ -108,7 +108,7 @@ LF_REACTOR_CTOR_SIGNATURE(MainSender) {
   LF_INITIALIZE_CLOCK_SYNC(Federate);
 }
 
-LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, SEC(1), true, 1)
+LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, SEC(1), true, 1, true)
 
 int main() {
   lf_start();

--- a/examples/riot/coap_federated/receiver/main.c
+++ b/examples/riot/coap_federated/receiver/main.c
@@ -93,7 +93,7 @@ LF_REACTOR_CTOR_SIGNATURE(MainRecv) {
   lf_connect_federated_input(&self->Receiver_Sender_bundle.inputs[0]->super, &self->receiver->in[0].super);
 }
 
-LF_ENTRY_POINT_FEDERATED(MainRecv, 32, 32, 32, SEC(1), true, 1)
+LF_ENTRY_POINT_FEDERATED(MainRecv, 32, 32, 32, SEC(1), true, 1, false)
 
 int main() {
   lf_start();

--- a/examples/riot/coap_federated/sender/main.c
+++ b/examples/riot/coap_federated/sender/main.c
@@ -103,7 +103,7 @@ LF_REACTOR_CTOR_SIGNATURE(MainSender) {
   LF_INITIALIZE_CLOCK_SYNC(Federate);
 }
 
-LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, SEC(1), true, 1)
+LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, SEC(1), true, 1, false)
 
 int main() {
   lf_start();

--- a/examples/zephyr/basic_federated/common/receiver.h
+++ b/examples/zephyr/basic_federated/common/receiver.h
@@ -106,4 +106,4 @@ LF_REACTOR_CTOR_SIGNATURE(MainRecv) {
   LF_INITIALIZE_CLOCK_SYNC(Federate);
   lf_connect_federated_input(&self->Receiver_Sender_bundle.inputs[0]->super, &self->receiver->in[0].super);
 }
-LF_ENTRY_POINT_FEDERATED(MainRecv,32,32,32, FOREVER, true, 1)
+LF_ENTRY_POINT_FEDERATED(MainRecv,32,32,32, FOREVER, true, 1, true)

--- a/examples/zephyr/basic_federated/federated_sender/src/sender.c
+++ b/examples/zephyr/basic_federated/federated_sender/src/sender.c
@@ -167,7 +167,7 @@ LF_REACTOR_CTOR_SIGNATURE(MainSender) {
   lf_connect_federated_output(self->Sender_Receiver2_bundle.outputs[0], self->sender->out);
 }
 
-LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, FOREVER, true, 2)
+LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, FOREVER, true, 2, true)
 
 int main() {
   setup_button();

--- a/include/reactor-uc/macros_internal.h
+++ b/include/reactor-uc/macros_internal.h
@@ -639,7 +639,7 @@ typedef struct FederatedInputConnection FederatedInputConnection;
   }
 
 #define LF_ENTRY_POINT_FEDERATED(FederateName, NumEvents, NumSystemEvents, NumReactions, Timeout, KeepAlive,           \
-                                 NumBundles)                                                                           \
+                                 NumBundles, DoClockSync)                                                              \
   static FederateName main_reactor;                                                                                    \
   static Environment env;                                                                                              \
   Environment *_lf_environment = &env;                                                                                 \
@@ -657,7 +657,7 @@ typedef struct FederatedInputConnection FederatedInputConnection;
     ReactionQueue_ctor(&reaction_queue, (Reaction **)reactions, level_size, (NumReactions));                           \
     Environment_ctor(&env, (Reactor *)&main_reactor, (Timeout), &event_queue, &system_event_queue, &reaction_queue,    \
                      (KeepAlive), true, false, (FederatedConnectionBundle **)&main_reactor._bundles, (NumBundles),     \
-                     &main_reactor.startup_coordinator.super, &main_reactor.clock_sync.super);                         \
+                     &main_reactor.startup_coordinator.super, (DoClockSync) ? &main_reactor.clock_sync.super : NULL);  \
     FederateName##_ctor(&main_reactor, NULL, &env);                                                                    \
     env.net_bundles_size = (NumBundles);                                                                               \
     env.net_bundles = (FederatedConnectionBundle **)&main_reactor._bundles;                                            \

--- a/test/platform/riot/coap_channel_federated_test/receiver/main.c
+++ b/test/platform/riot/coap_channel_federated_test/receiver/main.c
@@ -77,7 +77,7 @@ LF_DEFINE_STARTUP_COORDINATOR_STRUCT(Federate, 1, 5);
 LF_DEFINE_STARTUP_COORDINATOR_CTOR(Federate, 1, 1, 5);
 
 LF_DEFINE_CLOCK_SYNC_STRUCT(Federate, 1, 3);
-LF_DEFINE_CLOCK_SYNC_DEFAULTS_CTOR(Federate, 1, 3, false);
+// LF_DEFINE_CLOCK_SYNC_DEFAULTS_CTOR(Federate, 1, 3, false);
 
 typedef struct {
   Reactor super;
@@ -97,10 +97,10 @@ LF_REACTOR_CTOR_SIGNATURE(MainRecv) {
   LF_INITIALIZE_FEDERATED_CONNECTION_BUNDLE(Receiver, Sender);
   lf_connect_federated_input(&self->Receiver_Sender_bundle.inputs[0]->super, &self->receiver->in[0].super);
   LF_INITIALIZE_STARTUP_COORDINATOR(Federate);
-  LF_INITIALIZE_CLOCK_SYNC(Federate);
+  // LF_INITIALIZE_CLOCK_SYNC(Federate);
 }
 
-LF_ENTRY_POINT_FEDERATED(MainRecv,32,32,32, SEC(1), true, 1)
+LF_ENTRY_POINT_FEDERATED(MainRecv,32,32,32, SEC(1), true, 1, false)
 
 int main() {
   lf_start();

--- a/test/platform/riot/coap_channel_federated_test/sender/main.c
+++ b/test/platform/riot/coap_channel_federated_test/sender/main.c
@@ -77,7 +77,7 @@ LF_DEFINE_STARTUP_COORDINATOR_STRUCT(Federate, 1, 5);
 LF_DEFINE_STARTUP_COORDINATOR_CTOR(Federate, 1, 1, 5);
 
 LF_DEFINE_CLOCK_SYNC_STRUCT(Federate, 1, 3);
-LF_DEFINE_CLOCK_SYNC_DEFAULTS_CTOR(Federate, 1, 3, true);
+// LF_DEFINE_CLOCK_SYNC_DEFAULTS_CTOR(Federate, 1, 3, true);
 
 // Reactor main
 typedef struct {
@@ -99,11 +99,11 @@ LF_REACTOR_CTOR_SIGNATURE(MainSender) {
   LF_INITIALIZE_CHILD_REACTOR_WITH_PARAMETERS(Sender, sender, 1, _sender_out_args[i]);
   LF_INITIALIZE_FEDERATED_CONNECTION_BUNDLE(Sender, Receiver);
   LF_INITIALIZE_STARTUP_COORDINATOR(Federate);
-  LF_INITIALIZE_CLOCK_SYNC(Federate);
+  // LF_INITIALIZE_CLOCK_SYNC(Federate);
   lf_connect_federated_output((Connection *)self->Sender_Receiver_bundle.outputs[0], (Port *)self->sender->out);
 }
 
-LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, SEC(1), true, 1)
+LF_ENTRY_POINT_FEDERATED(MainSender,32,32,32, SEC(1), true, 1, false)
 
 int main() {
   lf_start();


### PR DESCRIPTION
Addresses #249 by just disabling the clock-sync for RIOT tests. The bug seems to be due to a problem in the RIOT native board  