### PR TITLE
Add Makefile rule for computing the complexity of our code-base

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,5 @@ Language: Cpp
 IndentWidth: 2
 ColumnLimit: 120
 AllowShortIfStatementsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
 SortIncludes: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean test coverage asan format format-check ci lf-test lib proto docs platform-test examples
+.PHONY: clean test coverage asan format format-check ci lf-test lib proto docs platform-test examples complexity
 
 test: unit-test lf-test platform-test examples
 
@@ -58,6 +58,9 @@ ci: clean test coverage format-check
 
 clean:
 	rm -rf build test/lf/src-gen test/lf/bin
+
+complexity:
+	complexity --histogram --score --thresh=2 $(SRC_FILES)
 
 docs:
 	mkdir -p doc/markdown/platform

--- a/include/reactor-uc/macros_internal.h
+++ b/include/reactor-uc/macros_internal.h
@@ -622,7 +622,9 @@ typedef struct FederatedInputConnection FederatedInputConnection;
   static Reaction *reactions[NumReactions][NumReactions];                                                              \
   static int level_size[NumReactions];                                                                                 \
   static ReactionQueue reaction_queue;                                                                                 \
-  void lf_exit(void) { Environment_free(&env); }                                                                       \
+  void lf_exit(void) {                                                                                                 \
+    Environment_free(&env);                                                                                            \
+  }                                                                                                                    \
   void lf_start() {                                                                                                    \
     EventQueue_ctor(&event_queue, events, NumEvents);                                                                  \
     ReactionQueue_ctor(&reaction_queue, (Reaction **)reactions, level_size, NumReactions);                             \
@@ -649,7 +651,9 @@ typedef struct FederatedInputConnection FederatedInputConnection;
   static Reaction *reactions[(NumReactions)][(NumReactions)];                                                          \
   static int level_size[(NumReactions)];                                                                               \
   static ReactionQueue reaction_queue;                                                                                 \
-  void lf_exit(void) { Environment_free(&env); }                                                                       \
+  void lf_exit(void) {                                                                                                 \
+    Environment_free(&env);                                                                                            \
+  }                                                                                                                    \
   void lf_start() {                                                                                                    \
     EventQueue_ctor(&event_queue, events, (NumEvents));                                                                \
     EventQueue_ctor(&system_event_queue, system_events, (NumSystemEvents));                                            \

--- a/include/reactor-uc/tag.h
+++ b/include/reactor-uc/tag.h
@@ -36,11 +36,15 @@
 #define FOREVER ((interval_t)LLONG_MAX)
 #define FOREVER_MICROSTEP UINT_MAX
 #define NEVER_TAG                                                                                                      \
-  (tag_t) { .time = NEVER, .microstep = NEVER_MICROSTEP }
+  (tag_t) {                                                                                                            \
+    .time = NEVER, .microstep = NEVER_MICROSTEP                                                                        \
+  }
 // Need a separate initializer expression to comply with some C compilers
 #define NEVER_TAG_INITIALIZER {NEVER, NEVER_MICROSTEP}
 #define FOREVER_TAG                                                                                                    \
-  (tag_t) { .time = FOREVER, .microstep = FOREVER_MICROSTEP }
+  (tag_t) {                                                                                                            \
+    .time = FOREVER, .microstep = FOREVER_MICROSTEP                                                                    \
+  }
 // Need a separate initializer expression to comply with some C compilers
 #define FOREVER_TAG_INITIALIZER {FOREVER, FOREVER_MICROSTEP}
 #define ZERO_TAG (tag_t){.time = 0LL, .microstep = 0u}

--- a/src/environment.c
+++ b/src/environment.c
@@ -65,7 +65,9 @@ interval_t Environment_get_logical_time(Environment *self) {
 interval_t Environment_get_elapsed_logical_time(Environment *self) {
   return self->scheduler->current_tag(self->scheduler).time - self->scheduler->start_time;
 }
-interval_t Environment_get_physical_time(Environment *self) { return self->clock.get_time(&self->clock); }
+interval_t Environment_get_physical_time(Environment *self) {
+  return self->clock.get_time(&self->clock);
+}
 interval_t Environment_get_elapsed_physical_time(Environment *self) {
   if (self->scheduler->start_time == NEVER) {
     return NEVER;
@@ -84,7 +86,9 @@ void Environment_leave_critical_section(Environment *self) {
   }
 }
 
-void Environment_request_shutdown(Environment *self) { self->scheduler->request_shutdown(self->scheduler); }
+void Environment_request_shutdown(Environment *self) {
+  self->scheduler->request_shutdown(self->scheduler);
+}
 
 void Environment_ctor(Environment *self, Reactor *main, interval_t duration, EventQueue *event_queue,
                       EventQueue *system_event_queue, ReactionQueue *reaction_queue, bool keep_alive, bool is_federated,

--- a/src/platform/flexpret/flexpret.c
+++ b/src/platform/flexpret/flexpret.c
@@ -3,7 +3,9 @@
 
 static PlatformFlexpret platform;
 
-void Platform_vprintf(const char *fmt, va_list args) { vprintf(fmt, args); }
+void Platform_vprintf(const char *fmt, va_list args) {
+  vprintf(fmt, args);
+}
 
 lf_ret_t PlatformFlexpret_initialize(Platform *super) {
   PlatformFlexpret *self = (PlatformFlexpret *)super;
@@ -108,4 +110,6 @@ void Platform_ctor(Platform *super) {
   self->num_nested_critical_sections = 0;
 }
 
-Platform *Platform_new(void) { return (Platform *)&platform; }
+Platform *Platform_new(void) {
+  return (Platform *)&platform;
+}

--- a/src/platform/patmos/patmos.c
+++ b/src/platform/patmos/patmos.c
@@ -8,7 +8,9 @@
 
 static PlatformPatmos platform;
 
-void Platform_vprintf(const char *fmt, va_list args) { vprintf(fmt, args); }
+void Platform_vprintf(const char *fmt, va_list args) {
+  vprintf(fmt, args);
+}
 
 lf_ret_t PlatformPatmos_initialize(Platform *super) {
   (void)super;
@@ -118,4 +120,6 @@ void Platform_ctor(Platform *super) {
   self->num_nested_critical_sections = 0;
 }
 
-Platform *Platform_new(void) { return (Platform *)&platform; }
+Platform *Platform_new(void) {
+  return (Platform *)&platform;
+}

--- a/src/platform/pico/pico.c
+++ b/src/platform/pico/pico.c
@@ -8,7 +8,9 @@
 
 static PlatformPico platform;
 
-void Platform_vprintf(const char *fmt, va_list args) { vprintf(fmt, args); }
+void Platform_vprintf(const char *fmt, va_list args) {
+  vprintf(fmt, args);
+}
 
 lf_ret_t PlatformPico_initialize(Platform *super) {
   PlatformPico *self = (PlatformPico *)super;
@@ -115,4 +117,6 @@ void Platform_ctor(Platform *super) {
   self->num_nested_critical_sections = 0;
 }
 
-Platform *Platform_new(void) { return (Platform *)&platform; }
+Platform *Platform_new(void) {
+  return (Platform *)&platform;
+}

--- a/src/platform/posix/posix.c
+++ b/src/platform/posix/posix.c
@@ -8,12 +8,18 @@
 
 static PlatformPosix platform;
 
-static instant_t convert_timespec_to_ns(struct timespec tp) { return ((instant_t)tp.tv_sec) * BILLION + tp.tv_nsec; }
+static instant_t convert_timespec_to_ns(struct timespec tp) {
+  return ((instant_t)tp.tv_sec) * BILLION + tp.tv_nsec;
+}
 
-void Platform_vprintf(const char *fmt, va_list args) { vprintf(fmt, args); }
+void Platform_vprintf(const char *fmt, va_list args) {
+  vprintf(fmt, args);
+}
 
 // lf_exit should be defined in main.c and should call Environment_free, if not we provide an empty implementation here.
-__attribute__((weak)) void lf_exit(void) { exit(0); }
+__attribute__((weak)) void lf_exit(void) {
+  exit(0);
+}
 
 static void handle_signal(int sig) {
   (void)sig;
@@ -134,4 +140,6 @@ void Platform_ctor(Platform *super) {
   super->new_async_event = PlatformPosix_new_async_event;
 }
 
-Platform *Platform_new(void) { return (Platform *)&platform; }
+Platform *Platform_new(void) {
+  return (Platform *)&platform;
+}

--- a/src/platform/posix/tcp_ip_channel.c
+++ b/src/platform/posix/tcp_ip_channel.c
@@ -66,7 +66,9 @@ static void _TcpIpChannel_update_state(TcpIpChannel *self, NetworkChannelState n
                        NetworkChannel_state_to_string(new_state));
 }
 
-static NetworkChannelState _TcpIpChannel_get_state_locked(TcpIpChannel *self) { return self->state; }
+static NetworkChannelState _TcpIpChannel_get_state_locked(TcpIpChannel *self) {
+  return self->state;
+}
 
 static NetworkChannelState _TcpIpChannel_get_state(TcpIpChannel *self) {
   NetworkChannelState state;

--- a/src/platform/riot/riot.c
+++ b/src/platform/riot/riot.c
@@ -13,7 +13,9 @@ static PlatformRiot platform;
 #define USEC_TO_NSEC(usec) (usec * USEC(1))
 #define NSEC_TO_USEC(nsec) (nsec / USEC(1))
 
-void Platform_vprintf(const char *fmt, va_list args) { vprintf(fmt, args); }
+void Platform_vprintf(const char *fmt, va_list args) {
+  vprintf(fmt, args);
+}
 
 lf_ret_t PlatformRiot_initialize(Platform *super) {
   PlatformRiot *self = (PlatformRiot *)super;
@@ -103,4 +105,6 @@ void Platform_ctor(Platform *super) {
   self->num_nested_critical_sections = 0;
 }
 
-Platform *Platform_new(void) { return (Platform *)&platform; }
+Platform *Platform_new(void) {
+  return (Platform *)&platform;
+}

--- a/src/platform/zephyr/zephyr.c
+++ b/src/platform/zephyr/zephyr.c
@@ -9,7 +9,9 @@
 
 static PlatformZephyr platform;
 
-void Platform_vprintf(const char *fmt, va_list args) { vprintk(fmt, args); }
+void Platform_vprintf(const char *fmt, va_list args) {
+  vprintk(fmt, args);
+}
 
 // Catch kernel panics from Zephyr
 void k_sys_fatal_error_handler(unsigned int reason, const struct arch_esf *esf) {
@@ -127,4 +129,6 @@ void Platform_ctor(Platform *super) {
   self->num_nested_critical_sections = 0;
 }
 
-Platform *Platform_new(void) { return (Platform *)&platform; }
+Platform *Platform_new(void) {
+  return (Platform *)&platform;
+}

--- a/src/queues.c
+++ b/src/queues.c
@@ -98,7 +98,9 @@ static lf_ret_t EventQueue_pop(EventQueue *self, AbstractEvent *event) {
   return LF_OK;
 }
 
-static bool EventQueue_empty(EventQueue *self) { return self->size == 0; }
+static bool EventQueue_empty(EventQueue *self) {
+  return self->size == 0;
+}
 
 void EventQueue_ctor(EventQueue *self, ArbitraryEvent *array, size_t capacity) {
   self->insert = EventQueue_insert;

--- a/src/schedulers/dynamic/scheduler.c
+++ b/src/schedulers/dynamic/scheduler.c
@@ -473,7 +473,9 @@ lf_ret_t Scheduler_schedule_at(Scheduler *self, AbstractEvent *event) {
   return res;
 }
 
-void Scheduler_set_duration(Scheduler *self, interval_t duration) { self->duration = duration; }
+void Scheduler_set_duration(Scheduler *self, interval_t duration) {
+  self->duration = duration;
+}
 
 void Scheduler_request_shutdown(Scheduler *untyped_self) {
   DynamicScheduler *self = (DynamicScheduler *)untyped_self;
@@ -510,7 +512,9 @@ lf_ret_t Scheduler_add_to_reaction_queue(Scheduler *untyped_self, Reaction *reac
   return self->reaction_queue->insert(self->reaction_queue, reaction);
 }
 
-tag_t Scheduler_current_tag(Scheduler *untyped_self) { return ((DynamicScheduler *)untyped_self)->current_tag; }
+tag_t Scheduler_current_tag(Scheduler *untyped_self) {
+  return ((DynamicScheduler *)untyped_self)->current_tag;
+}
 
 void DynamicScheduler_ctor(DynamicScheduler *self, Environment *env, EventQueue *event_queue,
                            EventQueue *system_event_queue, ReactionQueue *reaction_queue, interval_t duration,

--- a/src/schedulers/static/scheduler.c
+++ b/src/schedulers/static/scheduler.c
@@ -50,4 +50,6 @@ void StaticScheduler_ctor(StaticScheduler *self, Environment *env, const inst_t 
   self->super->set_and_schedule_start_tag = Scheduler_set_and_schedule_start_tag;
 }
 
-Scheduler *Scheduler_new(Environment *env, interval_t duration, bool keep_alive) { return (Scheduler *)&scheduler; }
+Scheduler *Scheduler_new(Environment *env, interval_t duration, bool keep_alive) {
+  return (Scheduler *)&scheduler;
+}

--- a/test/unit/action_empty_test.c
+++ b/test/unit/action_empty_test.c
@@ -12,9 +12,12 @@ LF_DEFINE_REACTION_BODY(ActionLib, reaction) {
   self->cnt++;
 }
 
-LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {}
+LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {
+}
 
-void test_run() { lf_start(); }
+void test_run() {
+  lf_start();
+}
 
 int main() {
   UNITY_BEGIN();

--- a/test/unit/action_microstep_test.c
+++ b/test/unit/action_microstep_test.c
@@ -31,8 +31,11 @@ LF_DEFINE_REACTION_BODY(ActionLib, reaction) {
   }
 }
 
-LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {}
-void test_run() { lf_start(); }
+LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {
+}
+void test_run() {
+  lf_start();
+}
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_run);

--- a/test/unit/action_overwrite_test.c
+++ b/test/unit/action_overwrite_test.c
@@ -21,8 +21,11 @@ LF_DEFINE_REACTION_BODY(ActionLib, reaction) {
   self->cnt++;
 }
 
-LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {}
-void test_run() { lf_start(); }
+LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {
+}
+void test_run() {
+  lf_start();
+}
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_run);

--- a/test/unit/action_test.c
+++ b/test/unit/action_test.c
@@ -26,9 +26,12 @@ LF_DEFINE_REACTION_BODY(ActionLib, reaction) {
   lf_schedule(act, MSEC(1), ++self->cnt);
 }
 
-LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {}
+LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {
+}
 
-void test_run() { lf_start(); }
+void test_run() {
+  lf_start();
+}
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_run);

--- a/test/unit/mock.c
+++ b/test/unit/mock.c
@@ -1,5 +1,7 @@
 #include "unity.h"
 
 // These can be overridden in the test files if needed
-__attribute__((weak)) void setUp(void) {}
-__attribute__((weak)) void tearDown(void) {}
+__attribute__((weak)) void setUp(void) {
+}
+__attribute__((weak)) void tearDown(void) {
+}

--- a/test/unit/request_shutdown_test.c
+++ b/test/unit/request_shutdown_test.c
@@ -25,7 +25,9 @@ LF_DEFINE_REACTION_BODY(ActionLib, r_shutdown) {
   TEST_ASSERT_EQUAL(1, env->scheduler->current_tag(env->scheduler).microstep);
 }
 
-void test_run() { lf_start(); }
+void test_run() {
+  lf_start();
+}
 int main() {
   UNITY_BEGIN();
   RUN_TEST(test_run);

--- a/test/unit/startup_test.c
+++ b/test/unit/startup_test.c
@@ -14,7 +14,9 @@ typedef struct {
   int cnt;
 } StartupTest;
 
-LF_DEFINE_REACTION_BODY(StartupTest, r_startup) { printf("Hello World\n"); }
+LF_DEFINE_REACTION_BODY(StartupTest, r_startup) {
+  printf("Hello World\n");
+}
 
 LF_REACTOR_CTOR_SIGNATURE(StartupTest) {
   LF_REACTOR_CTOR_PREAMBLE();


### PR DESCRIPTION
You need GNU Complexity for this, can easily be installed see here: https://www.cnx-software.com/2016/03/01/gnu-complexity-command-line-tool-measures-complexity-of-c-code/

Functions that are deemed too complex by this tool are:
Complexity | Line cnt | Code-line cnt 
   10     107      76   ./src/schedulers/dynamic/scheduler.c(306): Scheduler_run
   11      47      40   ./src/startup_coordinator.c(108): StartupCoordinator_handle_startup_handshake_request
   11      85      64   ./src/startup_coordinator.c(211): StartupCoordinator_handle_start_time_proposal
   12      66      58   ./src/federated.c(140): FederatedConnectionBundle_handle_tagged_msg
   25      62      50   ./src/platform/posix/tcp_ip_channel.c(255): TcpIpChannel_send_blocking
   28      90      72   ./src/platform/posix/tcp_ip_channel.c(415): _TcpIpChannel_worker_thread
   
  Complexity scores could be interpreted as:
  ‘0-9’ – Easily maintained code.
‘10-19’ – Maintained with little trouble.
‘20-29’ – Maintained with some effort.
‘30-39’ – Difficult to maintain code.
‘40-49’ – Hard to maintain code.
‘50-99’ – Unmaintainable code.
‘100-199’ – Crazy making difficult code.
‘200+’ – I only wish I were kidding.

I.e. we are not doing too bad. But some refactoring could help