### PR TITLE
TcpIpChannel worker thread regularly wake up to check for termination

### DIFF
--- a/src/platform/posix/posix.c
+++ b/src/platform/posix/posix.c
@@ -17,14 +17,13 @@ void Platform_vprintf(const char *fmt, va_list args) {
 }
 
 // lf_exit should be defined in main.c and should call Environment_free, if not we provide an empty implementation here.
-__attribute__((weak)) void lf_exit(void) {
-  exit(0);
-}
+__attribute__((weak)) void lf_exit(void) {}
 
 static void handle_signal(int sig) {
   (void)sig;
+  printf("ERROR: Caught signal %d\n", sig);
   lf_exit();
-  exit(0);
+  exit(1);
 }
 
 static struct timespec convert_ns_to_timespec(instant_t time) {

--- a/src/platform/posix/posix.c
+++ b/src/platform/posix/posix.c
@@ -17,7 +17,8 @@ void Platform_vprintf(const char *fmt, va_list args) {
 }
 
 // lf_exit should be defined in main.c and should call Environment_free, if not we provide an empty implementation here.
-__attribute__((weak)) void lf_exit(void) {}
+__attribute__((weak)) void lf_exit(void) {
+}
 
 static void handle_signal(int sig) {
   (void)sig;

--- a/src/platform/posix/tcp_ip_channel.c
+++ b/src/platform/posix/tcp_ip_channel.c
@@ -415,6 +415,7 @@ static void TcpIpChannel_close_connection(NetworkChannel *untyped_self) {
 static void *_TcpIpChannel_worker_thread(void *untyped_self) {
   TcpIpChannel *self = untyped_self;
   lf_ret_t ret;
+  int res;
 
   TCP_IP_CHANNEL_INFO("Starting worker thread");
 
@@ -460,13 +461,20 @@ static void *_TcpIpChannel_worker_thread(void *untyped_self) {
       FD_ZERO(&readfds);
       FD_SET(socket, &readfds);
       FD_SET(self->send_failed_event_fds[0], &readfds);
+      struct timeval timeout = {.tv_sec = 1, .tv_usec = 0};
 
       // Determine the maximum file descriptor for select
       max_fd = (socket > self->send_failed_event_fds[0]) ? socket : self->send_failed_event_fds[0];
 
       // Wait for data or cancel if send_failed externally
-      if (select(max_fd + 1, &readfds, NULL, NULL, NULL) < 0) {
+
+      res = select(max_fd + 1, &readfds, NULL, NULL, &timeout);
+      if (res < 0) {
         TCP_IP_CHANNEL_ERR("Select returned with error. errno=%d", errno);
+        _TcpIpChannel_update_state(self, NETWORK_CHANNEL_STATE_LOST_CONNECTION);
+        break;
+      } else if (res == 0) {
+        TCP_IP_CHANNEL_DEBUG("Select returned with a timeout.", errno);
         break;
       }
 

--- a/src/platform/posix/tcp_ip_channel.c
+++ b/src/platform/posix/tcp_ip_channel.c
@@ -466,7 +466,7 @@ static void *_TcpIpChannel_worker_thread(void *untyped_self) {
 
       // Wait for data or cancel if send_failed externally
       if (select(max_fd + 1, &readfds, NULL, NULL, NULL) < 0) {
-        TCP_IP_CHANNEL_ERR("Select returned with error. errno=", errno);
+        TCP_IP_CHANNEL_ERR("Select returned with error. errno=%d", errno);
         break;
       }
 

--- a/test/lf/src/FederatedMaxWaitNoHandler2.lf
+++ b/test/lf/src/FederatedMaxWaitNoHandler2.lf
@@ -25,6 +25,7 @@ reactor Dst {
   =} maxwait(0)
 
   reaction(shutdown) {=
+    printf("Dest is shutting down\n");
     validate(self->cnt == 2);
   =}
 }


### PR DESCRIPTION
I believe this PR will fix a subtle and rare race in termination. This PR adds a 1 second timeout to each call to `select`. Thus the TcpIp worker thread regularity wakes up to check whether a termination has been requested.