### PR TITLE
Rename MIN macro to prevent conflict with Zephyr's built-in MIN function

### DIFF
--- a/include/reactor-uc/tag.h
+++ b/include/reactor-uc/tag.h
@@ -21,7 +21,7 @@
 #define SECS(t) ((interval_t)(t * 1000000000LL))
 #define SECOND(t) ((interval_t)(t * 1000000000LL))
 #define SECONDS(t) ((interval_t)(t * 1000000000LL))
-#define MIN(t) ((interval_t)(t * 60000000000LL))
+#define MINS(t) ((interval_t)(t * 60000000000LL))
 #define MINUTE(t) ((interval_t)(t * 60000000000LL))
 #define MINUTES(t) ((interval_t)(t * 60000000000LL))
 #define HOUR(t) ((interval_t)(t * 3600000000000LL))


### PR DESCRIPTION
The MIN macro defined in the Lingua Franca template conflicts with a [MIN function](https://github.com/zephyrproject-rtos/zephyr/blob/f8d1d354c52e637a3deaea1b5f8d97c5092bb15b/include/zephyr/sys/ring_buffer.h#L389) in Zephyr 4.1.0 and the current main branch. This change avoids the conflict to ensure compatibility when upgrading Zephyr in the [lf-zephyr-uc-template](https://github.com/lf-lang/lf-zephyr-uc-template).

The error looks like this:
```shell
/Users/chang-yengtasi/lf-zephyr-uc-template/src-gen/Blinky/reactor-uc/include/reactor-uc/tag.h:24: note: macro "MIN" defined here
   24 | #define MIN(t) ((interval_t)(t * 60000000000LL))
      |
/Users/chang-yengtasi/lf-zephyr-uc-template/deps/zephyr/include/zephyr/sys/ring_buffer.h:379:36: error: 'MIN' undeclared (first use in this function)
  379 |                                    MIN(size, ring_buf_size_get(buf)));
      |                                    ^~~
```

Another possible approach is to submit a pull request to the Zephyr project itself, adding the following code to the file where MIN is used, in order to prevent macro conflicts:
```C
#ifdef MIN
#undef MIN
#endif
#define MIN(x, y) (((x) < (y)) ? (x) : (y))
```