### PR TITLE
add break in StartupCoordinationState_RUNNING case to stop implicit fallthrough

### DIFF
--- a/src/startup_coordinator.c
+++ b/src/startup_coordinator.c
@@ -251,6 +251,7 @@ static void StartupCoordinator_handle_start_time_proposal(StartupCoordinator *se
     case StartupCoordinationState_RUNNING:
       // Should not be possible.
       validate(false);
+      break;
     case StartupCoordinationState_HANDSHAKING:
       // This is possible. Our node might be still handshaking with another neighbor.
       // Intentional fall-through


### PR DESCRIPTION
Added a break into the `startup_coordinator.c`  `StartupCoordinator_handle_start_time_proposal` switch case. Without this the Zephyr build is broken due to a  `-Werror=implicit-fallthrough=` error. 

The case will exit the program if hit so the added break does not affect logical operations at all other than removing the warning/error.

```
In file included from /home/shea/git/lf-zephyr-uc-template/src-gen/HelloWorld/reactor-uc/include/reactor-uc/startup_coordinator.h:4,
                 from /home/shea/git/lf-zephyr-uc-template/src-gen/HelloWorld/reactor-uc/src/startup_coordinator.c:1:
/home/shea/git/lf-zephyr-uc-template/src-gen/HelloWorld/reactor-uc/src/startup_coordinator.c: In function ‘StartupCoordinator_handle_start_time_proposal’:
/home/shea/git/lf-zephyr-uc-template/src-gen/HelloWorld/reactor-uc/include/reactor-uc/error.h:32:8: error: this statement may fall through [-Werror=implicit-fallthrough=]
   32 |     if ((expr) == 0) {                                                                                                 \
      |        ^
/home/shea/git/lf-zephyr-uc-template/src-gen/HelloWorld/reactor-uc/src/startup_coordinator.c:253:7: note: in expansion of macro ‘validate’
  253 |       validate(false);
      |       ^~~~~~~~
/home/shea/git/lf-zephyr-uc-template/src-gen/HelloWorld/reactor-uc/src/startup_coordinator.c:254:5: note: here
  254 |     case StartupCoordinationState_HANDSHAKING:
      |     ^~~~
cc1: all warnings being treated as errors
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/bin/cmake --build /home/shea/git/lf-zephyr-uc-template/build --target run
```