### PR TITLE
Disable ridiculous linter error

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,8 @@ Checks: '
     -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
     -readability-function-cognitive-complexity,
     -modernize-macro-to-enum,
-    -readability-math-missing-parentheses
+    -readability-math-missing-parentheses,
+    -readability-use-concise-preprocessor-directives
     '
 WarningsAsErrors: true
 HeaderFilterRegex: ''


### PR DESCRIPTION
This PR disables the ridiculous linter error that requires changing
```
#if defined(FOO)
```
to
```
#ifdef FOO
```
This will have to merged without passing tests because the `Generate memory usage report (base branch)` runs the linter on the base branch, which will have this error until this PR is merged.