### PR TITLE
Fix pico mutex failing to init with >8 mutexes.

### DIFF
--- a/include/reactor-uc/platform/pico/pico.h
+++ b/include/reactor-uc/platform/pico/pico.h
@@ -14,7 +14,6 @@ typedef struct {
 
 typedef struct {
   Mutex super;
-  critical_section_t crit_sec;
 } MutexPico;
 
 #define PLATFORM_T PlatformPico

--- a/src/platform/pico/pico.c
+++ b/src/platform/pico/pico.c
@@ -104,5 +104,4 @@ void Mutex_ctor(Mutex* super) {
   if (!critical_section_is_initialized(&critical_section)) {
     critical_section_init(&critical_section);
   }
-  printf("Mutex initialized\n");
 }

--- a/src/platform/pico/pico.c
+++ b/src/platform/pico/pico.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 static PlatformPico platform;
+static critical_section_t critical_section;
 
 void Platform_vprintf(const char* fmt, va_list args) { vprintf(fmt, args); }
 
@@ -80,26 +81,28 @@ void Platform_ctor(Platform* super) {
 Platform* Platform_new() { return &platform.super; }
 
 void MutexPico_unlock(Mutex* super) {
-  MutexPico* self = (MutexPico*)super;
+  (void)super;
   PlatformPico* platform = (PlatformPico*)_lf_environment->platform;
   platform->num_nested_critical_sections--;
   if (platform->num_nested_critical_sections == 0) {
-    critical_section_exit(&self->crit_sec);
+    critical_section_exit(&critical_section);
   }
 }
 
 void MutexPico_lock(Mutex* super) {
-  MutexPico* self = (MutexPico*)super;
+  (void)super;
   PlatformPico* platform = (PlatformPico*)_lf_environment->platform;
   if (platform->num_nested_critical_sections == 0) {
-    critical_section_enter_blocking(&self->crit_sec);
+    critical_section_enter_blocking(&critical_section);
   }
   platform->num_nested_critical_sections++;
 }
 
 void Mutex_ctor(Mutex* super) {
-  MutexPico* self = (MutexPico*)super;
   super->lock = MutexPico_lock;
   super->unlock = MutexPico_unlock;
-  critical_section_init(&self->crit_sec);
+  if (!critical_section_is_initialized(&critical_section)) {
+    critical_section_init(&critical_section);
+  }
+  printf("Mutex initialized\n");
 }


### PR DESCRIPTION
Use a single static critical-section instead of initializing one for each mutex, which will eventually run out of hardware spinlocks after 8 initializations.

Explanation:
The pico-sdk allocates up to 8 out of the 32 HW spinlocks via the function spin_lock_claim_unused() that critical_section_init() uses.
14 spinlocks are reserved for the SDK
2 spinlocks are reserved for an OS
8 spinlocks are allocated by a different function: next_striped_spin_lock_num()

Reference:
https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_sync

The critical_section does two things:
- prevents higher priority interrupts on the same core (by disabling them)
- prevents access from the other core (using a spinlock)

Reference:
https://www.raspberrypi.com/documentation/pico-sdk/high_level.html#group_critical_section

That is why initializing a critical_section allocates a spinlock.
Also, sharing a critical_section between all mutexes is not a problem, since we (currently) are only running on a single core. For multicore execution, this could indeed cause unnecessary lock-contention... but we can handle that when it is supported.