### PR TITLE
Fix too many commas in ctor definition for custom network channel

### DIFF
--- a/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcNetworkChannel.kt
+++ b/lfc/core/src/main/kotlin/org/lflang/generator/uc/UcNetworkChannel.kt
@@ -421,9 +421,9 @@ class UcCustomChannel(
   private val srcArgs = if (srcIface.args != null) ", ${srcIface.args}" else ""
   private val destArgs = if (destIface.args != null) ", ${destIface.args}" else ""
 
-  override fun generateChannelCtorSrc() = "${srcIface.name}_ctor(&self->channel, ${srcArgs});"
+  override fun generateChannelCtorSrc() = "${srcIface.name}_ctor(&self->channel${srcArgs});"
 
-  override fun generateChannelCtorDest() = "${destIface.name}_ctor(&self->channel, ${destArgs});"
+  override fun generateChannelCtorDest() = "${destIface.name}_ctor(&self->channel${destArgs});"
 
   override val codeType: String
     get() = srcIface.name


### PR DESCRIPTION
The code generator adds one more comma than needed for the custom network channel constructor causing a C syntax error.
If the custom channel takes no arguments except the channel pointer, it would generate something like:
`MyCustomNetworkChannel_ctor(&self->channel,);`
With an argument it would generate:
`MyCustomNetworkChannel_ctor(&self->channel,,my_argument);`
I removed the extra comma in the generator function.